### PR TITLE
Added Hungarian translation

### DIFF
--- a/ConvertWinmailDat.sopm
+++ b/ConvertWinmailDat.sopm
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <otrs_package version="1.0">
     <Name>ConvertWinmailDat</Name>
-    <Version>5.0.1</Version>
+    <Version>5.0.2</Version>
     <Framework>4.0.x</Framework>
     <Framework>5.0.x</Framework>
     <Vendor>Perl-Services.de</Vendor>
     <URL>http://www.perl-services.de/</URL>
     <ModuleRequired Version="2.110">IO::Wrap</ModuleRequired>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
+    <ChangeLog Version="5.0.2" Date="2016-04-06 18:34:21">Added Hungarian translation, thanks to Balázs Úr.</ChangeLog>
     <Description Lang="en">Extract mail parts from winmail.dat and add them as attachments to ticket.</Description>
     <Description Lang="de">Füge Mailkomponenten aus winmail.dat als Anhänge an Ticket hinzu.</Description>
+    <Description Lang="hu">Levélrészek kibontása a winmail.dat fájlból, majd azok hozzáadása mellékletként a jegyhez.</Description>
     <Filelist>
         <File Permission="644" Location="doc/en/ConvertWinmailDat.pod"/>
+        <File Permission="644" Location="doc/hu/ConvertWinmailDat.pod"/>
         <File Permission="644" Location="Custom/Kernel/Modules/AgentTicketConvertWinmailDat.pm"/>
         <File Permission="644" Location="Custom/Kernel/Output/HTML/FilterElementPost/ConvertWinmail.pm"/>
         <File Permission="644" Location="Kernel/Config/Files/ConvertWinmailDat.xml"/>
@@ -19,5 +22,6 @@
         <File Permission="644" Location="Kernel/cpan-lib/Convert/TNEF.pm"/>
         <File Permission="644" Location="Kernel/System/ConvertWinmailDat/Utils.pm"/>
         <File Permission="644" Location="Kernel/Language/de_ConvertWinmailDat.pm"/>
+        <File Permission="644" Location="Kernel/Language/hu_ConvertWinmailDat.pm"/>
     </Filelist>
 </otrs_package>

--- a/Kernel/Config/Files/ConvertWinmailDat.xml
+++ b/Kernel/Config/Files/ConvertWinmailDat.xml
@@ -7,8 +7,8 @@
         <SubGroup>Core</SubGroup>
         <Setting>
             <Option SelectedID="0">
-                <Item Key="0">No</Item>
-                <Item Key="1">Yes</Item>
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -39,15 +39,14 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::Module###AgentTicketConvertWinmailDat" Required="0" Valid="1">
-        <Description Lang="en">Frontend module registration for the AgentTicketConvertWinmailDat module.</Description>
-        <Description Lang="de">Frontendmodul-Registration für das AgentTicketConvertWinmailDat Modul.</Description>
+        <Description  Translatable="1">Frontend module registration for the AgentTicketConvertWinmailDat module.</Description>
         <Group>ConvertWinmailDat</Group>
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>ConvertWinmailDat</Description>
+                <Description Translatable="1">Convert winmail.dat attachment.</Description>
                 <NavBarName></NavBarName>
-                <Title>ConvertWinmailDat</Title>
+                <Title Translatable="1">Convert winmail.dat</Title>
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>

--- a/Kernel/Language/de_ConvertWinmailDat.pm
+++ b/Kernel/Language/de_ConvertWinmailDat.pm
@@ -1,5 +1,5 @@
 # --
-# Kernel/Language/de_ConvertWinmailDat.pm - the german translation of ConvertWinmailDat
+# Kernel/Language/de_ConvertWinmailDat.pm - the German translation of ConvertWinmailDat
 # Copyright (C) 2015 Perl-Services, http://www.perl-services.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -21,7 +21,16 @@ sub Data {
 
     return if ref $Lang ne 'HASH';
 
-    $Lang->{"Convert TNEF attachments"} = 'Konvertiere TNEF-Anhänge';
+    $Lang->{'Convert TNEF attachments'} = 'Konvertiere TNEF-Anhänge';
+    $Lang->{'Enable Debugging for ConvertWinmailDat.'} = '';
+    $Lang->{'No'} = '';
+    $Lang->{'Yes'} = '';
+    $Lang->{'Module to convert winmail.dat attachments.'} = '';
+    $Lang->{'Add "convert" button to article menu.'} = '';
+    $Lang->{'Frontend module registration for the AgentTicketConvertWinmailDat module.'} =
+        'Frontendmodul-Registration für das AgentTicketConvertWinmailDat Modul.';
+    $Lang->{'Convert winmail.dat attachment.'} = '';
+    $Lang->{'Convert winmail.dat'} = '';
 
     return 1;
 }

--- a/Kernel/Language/hu_ConvertWinmailDat.pm
+++ b/Kernel/Language/hu_ConvertWinmailDat.pm
@@ -1,6 +1,7 @@
 # --
 # Kernel/Language/hu_ConvertWinmailDat.pm - the Hungarian translation of ConvertWinmailDat
 # Copyright (C) 2016 Perl-Services, http://www.perl-services.de
+# Copyright (C) 2015 Balázs Úr, http://www.otrs-megoldasok.hu
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you

--- a/Kernel/Language/hu_ConvertWinmailDat.pm
+++ b/Kernel/Language/hu_ConvertWinmailDat.pm
@@ -1,0 +1,38 @@
+# --
+# Kernel/Language/hu_ConvertWinmailDat.pm - the Hungarian translation of ConvertWinmailDat
+# Copyright (C) 2016 Perl-Services, http://www.perl-services.de
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::hu_ConvertWinmailDat;
+
+use strict;
+use warnings;
+
+use utf8;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation};
+
+    return if ref $Lang ne 'HASH';
+
+    $Lang->{'Convert TNEF attachments'} = 'TNEF-mellékletek átalakítása';
+    $Lang->{'Enable Debugging for ConvertWinmailDat.'} = 'Hibakeresés engedélyezése a ConvertWinmailDat modulnál.';
+    $Lang->{'No'} = 'Nem';
+    $Lang->{'Yes'} = 'Igen';
+    $Lang->{'Module to convert winmail.dat attachments.'} = 'Egy modul winmail.dat mellékletek átalakításához.';
+    $Lang->{'Add "convert" button to article menu.'} = '„Átalakítás” gomb hozzáadása a bejegyzés menühöz.';
+    $Lang->{'Frontend module registration for the AgentTicketConvertWinmailDat module.'} =
+        'Előtétprogram-modul regisztráció az AgentTicketConvertWinmailDat modulhoz.';
+    $Lang->{'Convert winmail.dat attachment.'} = 'A winmail.dat melléklet átalakítása.';
+    $Lang->{'Convert winmail.dat'} = 'A winmail.dat átalakítása';
+
+    return 1;
+}
+
+1;

--- a/doc/hu/ConvertWinmailDat.pod
+++ b/doc/hu/ConvertWinmailDat.pod
@@ -1,0 +1,42 @@
+=head1 NÉV
+
+ConvertWinmailDat - Mellékletek kibontása winmail.dat fájlból
+
+=head1 LEÍRÁS
+
+Az Outlook néha egy winmail.dat fájlt csatol, amely az eredeti mellékleteket tartalmazza. Az
+a fájl szabadalomvédett formátummal kódolt, és az Outlooktól eltérő levelezőklienssel nem
+lesz képes az eredeti mellékleteket megszerezni.
+
+Ez az OTRS bővítmény egy olyan PostMaster szűrőként lett megvalósítva, amely leellenőrzi,
+hogy egy bejövő levélnek van-e mellékelt winmail.dat nevű fájlja. Ha egy ilyen melléklet
+található, akkor az eredeti mellékletek ki lesznek bontva, és hozzá lesznek adva a
+bejegyzéshez. Azonban a winmail.dat melléklet továbbra is a bejegyzéshez lesz csatolva.
+
+A telepítés után nincs további tennivaló.
+
+=head1 TELEPÍTÉS
+
+Ezt a csomagot telepítheti a beépített OTRS csomagkezelővel (az Adminisztrációs területen)
+vagy parancssorból:
+
+OTRS 2.4.x:
+
+  perl bin/opm.pl -a install -p ConvertWinmailDat.opm
+
+OTRS >= 3.0.x
+
+  perl bin/otrs.PackageManager.pl -a install -p ConvertWinmailDat.opm
+
+=head1 SZERZŐ ÉS LICENC
+
+Ez a csomag az AGPL3 feltételi szerint licencelt. Lásd: 
+L<http://www.gnu.org/licenses/agpl.txt>
+
+Copyright (c) 2012 Perl-Services.de, L<http://otrs.perl-services.de>
+
+=head1 MAGYAR FORDÍTÁS
+
+A magyar fordítást az OTRS-megoldások csapata készítette.
+Copyright (c) 2015 Úr Balázs, L<http://otrs-megoldasok.hu>
+


### PR DESCRIPTION
Hi @reneeb

Here is the complete Hungarian translation for ConvertWinmailDat module. I added the missing translatable messages to Kernel/Language/de_ConvertWinmailDat.pm, so you can put the German texts into the language file, before releasing version 5.0.2 of this module.

Regards,
Balázs
